### PR TITLE
Fix Issues86&87：填充item3.md和item40.md中的空链接为相应内容

### DIFF
--- a/1.DeducingTypes/item3.md
+++ b/1.DeducingTypes/item3.md
@@ -113,7 +113,7 @@ std::deque<std::string> makeStringDeque();      //工厂函数
 //从makeStringDeque中获得第五个元素的拷贝并返回
 auto s = authAndAccess(makeStringDeque(), 5);
 ````
-要想支持这样使用`authAndAccess`我们就得修改一下当前的声明使得它支持左值和右值。重载是一个不错的选择（一个函数重载声明为左值引用，另一个声明为右值引用），但是我们就不得不维护两个重载函数。另一个方法是使`authAndAccess`的引用可以绑定左值和右值，[Item24]()解释了那正是通用引用能做的，所以我们这里可以使用通用引用进行声明：
+要想支持这样使用`authAndAccess`我们就得修改一下当前的声明使得它支持左值和右值。重载是一个不错的选择（一个函数重载声明为左值引用，另一个声明为右值引用），但是我们就不得不维护两个重载函数。另一个方法是使`authAndAccess`的引用可以绑定左值和右值，[Item24](https://github.com/kelthuzadx/EffectiveModernCppChinese/blob/master/5.RRefMovSemPerfForw/item24.md)解释了那正是通用引用能做的，所以我们这里可以使用通用引用进行声明：
 ````cpp
 template<typename Containter, typename Index>   //现在c是通用引用
 decltype(auto) authAndAccess(Container&& c, Index i);

--- a/7.TheConcurrencyAPI/item40.md
+++ b/7.TheConcurrencyAPI/item40.md
@@ -60,7 +60,7 @@ volatile int vc(0);             //“volatile计数器”
 
 不仅只有这一种可能的结果，通常来说`vc`的最终结果是不可预测的，因为`vc`会发生数据竞争，对于数据竞争造成未定义行为，标准规定表示编译器生成的代码可能是任何逻辑。当然，编译器不会利用这种行为来作恶。但是它们通常做出一些没有数据竞争的程序中才有效的优化，这些优化在存在数据竞争的程序中会造成异常和不可预测的行为。
 
-RMW操作不是仅有的`std::atomic`在并发中有效而`volatile`无效的例子。假定一个任务计算第二个任务需要的一个重要的值。当第一个任务完成计算，必须传递给第二个任务。[Item39]()表明一种使用`std::atomic<bool>`的方法来使第一个任务通知第二个任务计算完成。计算值的任务的代码如下：
+RMW操作不是仅有的`std::atomic`在并发中有效而`volatile`无效的例子。假定一个任务计算第二个任务需要的一个重要的值。当第一个任务完成计算，必须传递给第二个任务。[Item39](https://github.com/kelthuzadx/EffectiveModernCppChinese/blob/master/7.TheConcurrencyAPI/item39.md)表明一种使用`std::atomic<bool>`的方法来使第一个任务通知第二个任务计算完成。计算值的任务的代码如下：
 
 ```cpp
 std::atomic<bool> valVailable(false); 


### PR DESCRIPTION
将`item3.md`和`item40.md`中的空链接填充为相应内容